### PR TITLE
🔖 4.0.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,9 @@
+### [4.0.2] (2026-12-07)
+
+- 🐛 Fix package metadata to support Python 3.14
+
+---
+
 ### [4.0.1] (2026-12-07)
 
 - 🐍 Add support for Python 3.12, 3.13, and 3.14 in package metadata
@@ -220,3 +226,4 @@ Add [py.typed](..%2Fiter_model%2Fpy.typed) file to package
 [3.0.0]: https://github.com/VolodymyrBor/iter_model/pull/33
 [4.0.0]: https://github.com/VolodymyrBor/iter_model/pull/35
 [4.0.1]: https://github.com/VolodymyrBor/iter_model/pull/36
+[4.0.2]: https://github.com/VolodymyrBor/iter_model/pull/37

--- a/poetry.lock
+++ b/poetry.lock
@@ -1109,5 +1109,5 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.10,<=3.14"
-content-hash = "a082d21a24213353ce15fc64a4c4ac9b26db7b7867f9ab949b87995efb96db31"
+python-versions = ">=3.10,<3.15"
+content-hash = "e2c1160d23f277e2e2d514c839a883e8805fe0dad6addce0a9dfa49b499d0975"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iter_model"
-version = "4.0.1"
+version = "4.0.2"
 description = "iter-model uses a method approach instead of individual functions to work with iterable objects."
 authors = ["volodymyrb <volodymyr.borysiuk0@gmail.com>"]
 license = "MIT"
@@ -12,7 +12,7 @@ keywords = ["iterator", "iterable", 'async']
 include = ["iter_model/py.typed"]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<=3.14"
+python = ">=3.10,<3.15"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.4"


### PR DESCRIPTION
### [4.0.2] (2026-12-07)

- 🐛 Fix package metadata to support Python 3.14

[4.0.2]: https://github.com/VolodymyrBor/iter_model/pull/37