### PR TITLE
🔖 4.0.3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,9 @@
+### [4.0.3] (2026-12-07)
+
+- 🐛 Fix package metadata to support Python 3.14
+
+---
+
 ### [4.0.2] (2026-12-07)
 
 - 🐛 Fix package metadata to support Python 3.14
@@ -227,3 +233,4 @@ Add [py.typed](..%2Fiter_model%2Fpy.typed) file to package
 [4.0.0]: https://github.com/VolodymyrBor/iter_model/pull/35
 [4.0.1]: https://github.com/VolodymyrBor/iter_model/pull/36
 [4.0.2]: https://github.com/VolodymyrBor/iter_model/pull/37
+[4.0.3]: https://github.com/VolodymyrBor/iter_model/pull/38

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iter_model"
-version = "4.0.2"
+version = "4.0.3"
 description = "iter-model uses a method approach instead of individual functions to work with iterable objects."
 authors = ["volodymyrb <volodymyr.borysiuk0@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### [4.0.3] (2026-12-07)

- 🐛 Fix package metadata to support Python 3.14

[4.0.3]: https://github.com/VolodymyrBor/iter_model/pull/38