### PR TITLE
🔖  4.0.4

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,9 @@
+### [4.0.4] (2026-12-07)
+
+- 🐛 Fix package metadata to support Python 3.14
+
+---
+
 ### [4.0.3] (2026-12-07)
 
 - 🐛 Fix package metadata to support Python 3.14
@@ -234,3 +240,4 @@ Add [py.typed](..%2Fiter_model%2Fpy.typed) file to package
 [4.0.1]: https://github.com/VolodymyrBor/iter_model/pull/36
 [4.0.2]: https://github.com/VolodymyrBor/iter_model/pull/37
 [4.0.3]: https://github.com/VolodymyrBor/iter_model/pull/38
+[4.0.4]: https://github.com/VolodymyrBor/iter_model/pull/39

--- a/poetry.lock
+++ b/poetry.lock
@@ -1109,5 +1109,5 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.10,<3.15"
-content-hash = "e2c1160d23f277e2e2d514c839a883e8805fe0dad6addce0a9dfa49b499d0975"
+python-versions = ">=3.10"
+content-hash = "a514c3be522b2fbb14b2ed560901510b1af6ed74df3a167d32b33501118faef3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["iterator", "iterable", 'async']
 include = ["iter_model/py.typed"]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.15"
+python = ">=3.10"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.4"


### PR DESCRIPTION
### [4.0.4] (2026-12-07)

- 🐛 Fix package metadata to support Python 3.14

[4.0.4]: https://github.com/VolodymyrBor/iter_model/pull/39